### PR TITLE
fix: coordinator: print error message when watchtower is unable to login

### DIFF
--- a/src/client/coordinator/auth/auth.go
+++ b/src/client/coordinator/auth/auth.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"io"
 
 	"golang.org/x/net/publicsuffix"
 
@@ -129,6 +130,15 @@ func (cc CoordinatorClient) doLogin(message string) (int, error) {
 		return -1, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			wtCommon.Error(err)
+		}
+		bodyString := string(bodyBytes)
+		wtCommon.Error(bodyString)
+	}
+
 	return resp.StatusCode, nil
 }
 


### PR DESCRIPTION
This pull request logs error messages on failure during login